### PR TITLE
Converge to Dependabot; remove .renovaterc.json

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,9 +1,0 @@
-{
-  "separateMajorMinor": false,
-  "extends": [
-    "config:base",
-    ":prHourlyLimit1",
-    ":preserveSemverRanges",
-    "docker:enableMajor"
-  ]
-}


### PR DESCRIPTION
Converging on Dependabot to match the rest of the c65sdn org. The existing Renovate config has not been producing PRs (the Renovate app does not appear to be active on this org), so this swap restores actual dependency-update coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)